### PR TITLE
Implement the package merge algorithm

### DIFF
--- a/src/entropy_coding/mod.rs
+++ b/src/entropy_coding/mod.rs
@@ -1,4 +1,5 @@
 pub mod ac_io;
+pub mod package_merge;
 #[cfg(test)]
 mod tests;
 

--- a/src/entropy_coding/package_merge.rs
+++ b/src/entropy_coding/package_merge.rs
@@ -10,12 +10,16 @@ fn package_merge(counts: &[u32], max_len: u8) -> Vec<u8> {
     let sorted_counts: Vec<_> = symbol2count.iter().map(|&x| x.1).collect();
 
     assert!(sorted_counts.len() != 0, "No symbols provided");
-    assert!(sorted_counts.len() <= 1 << max_len, "Max length is too small");
     assert!(max_len <= 32, "Max length is too big");
+    assert!(
+        sorted_counts.len() <= 1 << max_len,
+        "Max length is too small"
+    );
 
     let sorted_code_lens = package_merge_sorted(&sorted_counts, max_len);
     let mut code_lens = vec![0; counts.len()];
-    symbol2count.iter()
+    symbol2count
+        .iter()
         .map(|x| x.0)
         .zip(sorted_code_lens)
         .for_each(|(sym, code_len)| code_lens[sym] = code_len);
@@ -29,34 +33,31 @@ fn package_merge(counts: &[u32], max_len: u8) -> Vec<u8> {
 fn package_merge_sorted(a: &[u32], max_len: u8) -> Vec<u8> {
     let mut package_depths: Vec<u32> = vec![0; a.len() * 2 - 1];
     let mut prev: Vec<u32> = a.iter().copied().collect();
+    let mut curr = Vec::with_capacity(a.len() * 2 - 1);
 
     for depth in 1..max_len {
         let mask = 1 << depth; // records at which depth it was packaged
-        let mut seq = a.iter().peekable();
+        let mut seq = a.iter().peekable(); // always merge with the initial counts
         let mut packages = prev.chunks_exact(2).map(|x| x[0] + x[1]).peekable();
-        let mut curr = Vec::with_capacity(a.len() + prev.len() / 2 + 2);
+        curr.clear(); //
 
-        // merge packages with original sequence
+        // merge iteration
         loop {
-            // TODO: refactor
-            let (next_item, is_package) = match (seq.peek(), packages.peek()) {
+            let is_package = match (packages.peek(), seq.peek()) {
                 (None, None) => break,
-                (_, None) => (seq.next().copied(), false), // merged all packages
-                (None, _) => (packages.next(), true),      // merged original sequence
-                (Some(&a), Some(b)) => {
-                    if a <= b {
-                        (seq.next().copied(), false)
-                    } else {
-                        (packages.next(), true)
-                    }
-                }
+                (None, _) => false,
+                (_, None) => true,
+                (Some(a), Some(&b)) => a <= b,
             };
-            if is_package {
+            let next_item = if is_package {
                 package_depths[curr.len()] |= mask;
-            }
-            curr.push(next_item.unwrap());
+                packages.next().unwrap()
+            } else {
+                seq.next().copied().unwrap()
+            };
+            curr.push(next_item);
         }
-        prev = curr; // TODO: mem swap for efficiency
+        std::mem::swap(&mut prev, &mut curr);
     }
 
     let mut code_lens = vec![0; a.len()];
@@ -93,11 +94,11 @@ mod tests {
 
     #[test]
     fn stephan_brumme_example() {
-        assert_eq!(package_merge(&[270, 20, 10, 0, 1, 6, 1], 4), [1, 2, 4, 0, 4, 4, 4]);
-        assert_eq!(package_merge(&[10, 20, 270, 0, 1, 6, 1], 4), [4, 2, 1, 0, 4, 4, 4]);
+        let counts = [270, 20, 10, 0, 1, 6, 1];
+        assert_eq!(package_merge(&counts, 4), [1, 2, 4, 0, 4, 4, 4]);
+        let counts = [10, 20, 270, 0, 1, 6, 1];
+        assert_eq!(package_merge(&counts, 4), [4, 2, 1, 0, 4, 4, 4]);
     }
-
-    // TODO: enwik8, book1 frequencies
 
     #[test]
     fn single_symbol() {

--- a/src/entropy_coding/package_merge.rs
+++ b/src/entropy_coding/package_merge.rs
@@ -1,0 +1,114 @@
+// fn package_merge(counts: Vec<u32>, max_len: u8) {
+//     let mut symbol_map: Vec<_> = counts
+//         .iter()
+//         .copied()
+//         .enumerate()
+//         .filter(|&(_, count)| count != 0)
+//         .collect();
+//     // sort symbols by counts
+//     symbol_map.sort_unstable_by(|(_, a), (_, b)| a.cmp(b));
+//     let sorted_counts: Vec<_> = symbol_map.iter().map(|&x| x.1).collect();
+//     let code_lens = package_merge_in_place(&sorted_counts, max_len);
+
+//     todo!()
+//     // do some un-sorting
+//     // counts.sort();
+// }
+
+// Inspired by
+// https://create.stephan-brumme.com/length-limited-prefix-codes/#package-merge
+// https://github.com/sellibitze/packagemerge-rs/blob/27adc64e3a8b51b86ea91449c6a4c1971af7c682/src/lib.rs
+fn package_merge_sorted(a: &[u32], max_len: u8) -> Vec<u32> {
+    let mut package_depths: Vec<u32> = vec![0; a.len() * 2 - 1];
+    let mut prev: Vec<u32> = a.iter().copied().collect();
+
+    for depth in 1..max_len {
+        let mask = 1 << depth; // records at which depth it was packaged
+        let mut seq = a.iter().peekable();
+        let mut packages = prev.chunks_exact(2).map(|x| x[0] + x[1]).peekable();
+        let mut curr = Vec::with_capacity(a.len() + prev.len() / 2 + 2);
+
+        // merge packages with original sequence
+        loop {
+            // TODO: refactor
+            let (next_item, is_package) = match (seq.peek(), packages.peek()) {
+                (None, None) => break,
+                (_, None) => (seq.next().copied(), false), // merged all packages
+                (None, _) => (packages.next(), true),      // merged original sequence
+                (Some(&a), Some(b)) => {
+                    if a <= b {
+                        (seq.next().copied(), false)
+                    } else {
+                        (packages.next(), true)
+                    }
+                }
+            };
+            if is_package {
+                package_depths[curr.len()] |= mask;
+            }
+            curr.push(next_item.unwrap());
+        }
+        prev = curr; // TODO: mem swap for efficiency
+    }
+
+    let mut code_lens = vec![0; a.len()];
+    let mut relevant_symbols = a.len() * 2 - 2;
+    for depth in (0..max_len).rev() {
+        if relevant_symbols == 0 {
+            break;
+        }
+        let mask = 1 << depth;
+        let mut packaged = 0;
+        for sym in 0..relevant_symbols {
+            // if it hasn't been merged, we increase it's code length
+            if package_depths[sym] & mask == 0 {
+                code_lens[sym - packaged] += 1;
+            } else {
+                packaged += 1;
+            }
+        }
+        relevant_symbols = packaged * 2;
+    }
+    code_lens
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sellibitze_example() {
+        let mut counts = [1, 32, 16, 4, 8, 2, 1];
+        counts.sort(); // TODO:
+        // assert_eq!(package_merge(&counts, 8), [6, 1, 2, 4, 3, 5, 6]); // TODO:
+        assert_eq!(package_merge_sorted(&counts, 8), [6, 6, 5, 4, 3, 2, 1]);
+        // assert_eq!(package_merge(&counts, 5), [5, 1, 2, 5, 3, 5, 5]); // TODO:
+        assert_eq!(package_merge_sorted(&counts, 5), [5, 5, 5, 5, 3, 2, 1]);
+    }
+
+    #[test]
+    fn stephan_brumme_example() {
+        // let mut counts = [270, 20, 10, 0, 1, 6, 1]; // TODO:
+        let counts = [1, 1, 6, 10, 20, 270];
+        assert_eq!(package_merge_sorted(&counts, 4), [4, 4, 4, 4, 2, 1]);
+    }
+
+    // TODO: enwik8, book1 frequencies
+
+    #[test]
+    fn single_symbol() {
+        for max_len in [1, 2, 8] {
+            assert_eq!(package_merge_sorted(&[1], max_len), [0]);
+            assert_eq!(package_merge_sorted(&[10], max_len), [0]);
+        }
+    }
+
+    #[test]
+    fn two_symbols() {
+        for max_len in [1, 2, 8] {
+            assert_eq!(package_merge_sorted(&[1, 1], max_len), [1, 1]);
+            assert_eq!(package_merge_sorted(&[10, 10], max_len), [1, 1]);
+            assert_eq!(package_merge_sorted(&[1, 100], max_len), [1, 1]);
+        }
+    }
+}

--- a/src/entropy_coding/package_merge.rs
+++ b/src/entropy_coding/package_merge.rs
@@ -72,7 +72,7 @@ fn package_merge_sorted(a: &[u32], max_len: u8) -> Vec<u8> {
         package_depths
             .iter()
             .take(relevant_symbols)
-            .filter(|&flag| flag & mask != 0)
+            .filter(|&flag| flag & mask == 0)
             .for_each(|_| {
                 code_lens[sym] += 1;
                 sym += 1; // move to the next non-packaged symbol

--- a/src/entropy_coding/package_merge.rs
+++ b/src/entropy_coding/package_merge.rs
@@ -10,7 +10,7 @@ fn package_merge(counts: &[u32], max_len: u8) -> Vec<u8> {
     let sorted_counts: Vec<_> = symbol2count.iter().map(|&x| x.1).collect();
 
     assert!(sorted_counts.len() != 0, "No symbols provided");
-    assert!(max_len <= 32, "Max length is too big");
+    assert!(max_len <= 32, "Max length is too big"); // can be 64 for quad words
     assert!(
         sorted_counts.len() <= 1 << max_len,
         "Max length is too small"
@@ -41,7 +41,7 @@ fn package_merge_sorted(a: &[u32], max_len: u8) -> Vec<u8> {
         let mut packages = prev.chunks_exact(2).map(|x| x[0] + x[1]).peekable();
         curr.clear(); //
 
-        // merge iteration
+        // merge packages from prev with initial sequence
         loop {
             let is_package = match (packages.peek(), seq.peek()) {
                 (None, None) => break,
@@ -101,6 +101,37 @@ mod tests {
     }
 
     #[test]
+    fn book1() {
+        let book1_counts = [
+            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16622, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+            0, 0, 0, 0, 125551, 832, 2468, 0, 0, 0, 1, 6470, 43, 40, 1, 691, 10296, 3955, 7170, 0,
+            98, 240, 185, 184, 151, 96, 87, 85, 85, 82, 220, 762, 498, 5, 498, 759, 0, 967, 1463,
+            580, 269, 444, 413, 575, 977, 2899, 253, 45, 413, 565, 502, 856, 693, 14, 245, 850,
+            1966, 103, 64, 753, 5, 416, 0, 0, 0, 0, 0, 0, 0, 47836, 9132, 12685, 26623, 72431,
+            12237, 12303, 37561, 37007, 468, 4994, 23078, 14044, 40919, 44795, 9332, 520, 32889,
+            36788, 50027, 16031, 5382, 14071, 861, 11986, 264, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+        ];
+        let code_lens = [
+            12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12, 0,
+            0, 0, 0, 0, 3, 10, 8, 0, 0, 0, 12, 7, 12, 12, 12, 10, 6, 7, 7, 0, 12, 12, 12, 12, 12,
+            12, 12, 12, 12, 12, 12, 10, 10, 12, 10, 10, 0, 10, 9, 10, 11, 11, 11, 10, 10, 8, 11,
+            12, 11, 10, 10, 10, 10, 12, 12, 10, 9, 12, 12, 10, 12, 11, 0, 0, 0, 0, 0, 0, 0, 4, 6,
+            6, 5, 3, 6, 6, 4, 4, 11, 7, 5, 6, 4, 4, 6, 10, 5, 5, 4, 6, 7, 6, 10, 6, 11, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        assert_eq!(package_merge(&book1_counts, 12), code_lens);
+    }
+
+    #[test]
     fn single_symbol() {
         for max_len in [1, 2, 8] {
             assert_eq!(package_merge(&[1], max_len), [0]);
@@ -118,9 +149,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Max length is too small")]
-    fn max_len_too_small() {
-        package_merge(&[1, 1, 2, 4, 8, 16, 32], 2);
+    #[should_panic(expected = "No symbols provided")]
+    fn no_symbols() {
+        assert_eq!(package_merge(&[], 8), &[]);
     }
 
     #[test]
@@ -130,8 +161,8 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "No symbols provided")]
-    fn no_symbols() {
-        assert_eq!(package_merge(&[], 8), &[]);
+    #[should_panic(expected = "Max length is too small")]
+    fn max_len_too_small() {
+        package_merge(&[1, 1, 2, 4, 8, 16, 32], 2);
     }
 }


### PR DESCRIPTION
Useful links:
- Stephan Brumme's [page](https://create.stephan-brumme.com/length-limited-prefix-codes/#package-merge) on length-limited prefix codes
- cbloom's [blog post](https://cbloomrants.blogspot.com/2010/07/07-02-10-length-limitted-huffman-codes.html) on length limited huffman codes
- this [medium article](https://experiencestack.co/length-limited-huffman-codes-21971f021d43) by Hayden Sather has been sorta helpful for visualisation
- this [old page](https://125-problems.univ-mlv.fr/problem100.php) has a somewhat nice diagram
- a real world example from [mcm](https://github.com/mathieuchartier/mcm/blob/1c44c95a3c90df01939757a8cceb556d8b55a7d0/Huffman.hpp#L123)
- sellibitze's [rust library](https://github.com/sellibitze/packagemerge-rs/blob/27adc64e3a8b51b86ea91449c6a4c1971af7c682/src/lib.rs)

The algorithm is roughly split in 3 parts:
- sort the histogram / counts array (in a reversible way)
  - I had most of the code for this from working on rewriting the Moffat alg
- do `max_len` iterations packaging / merging
  - the rust solution for this was with itertools, and I don't know if it's faster than mine but I doubt it
  - my biggest concern is the optimizer won't drop the unwraps after peeking
- increment / compute code lengths
  - this piece I rewrote in a pretty rusty way I think