### PR TITLE
[ac-history] Fix: predict in forward direction, encode backwards

### DIFF
--- a/src/bin/entropy-hashing-ac/main.rs
+++ b/src/bin/entropy-hashing-ac/main.rs
@@ -4,7 +4,7 @@ use weath3rb0i::{
     entropy_coding::arithmetic_coder::ArithmeticCoder,
     helpers::ACStats,
     history::{ACHistory, History},
-    models::{ac_hash::StationaryModel, Model, OrderNEntropy},
+    models::{FrozenModel, Model, Order0, OrderNEntropy},
     u64, unroll_for,
 };
 
@@ -16,7 +16,8 @@ fn main() -> Result<()> {
     let mut best = vec![u64!(buf.len()); levels];
     let mut params = vec![(0, 0); levels];
 
-    let model = StationaryModel::new(&buf);
+    let mut model = FrozenModel::new(Order0::new());
+    model.train(&buf);
 
     for ctx_bits in 8..=30 {
         best[1] = u64!(buf.len());

--- a/src/bin/entropy-hashing-ac/main.rs
+++ b/src/bin/entropy-hashing-ac/main.rs
@@ -19,7 +19,7 @@ fn main() -> Result<()> {
     let mut model = FrozenModel::new(Order0::new());
     model.train(&buf);
 
-    for ctx_bits in 8..=30 {
+    for ctx_bits in 8..=25 {
         best[1] = u64!(buf.len());
         params[1] = (0, 0);
         for alignment_bits in 0..=4 {

--- a/src/entropy_coding/arithmetic_coder.rs
+++ b/src/entropy_coding/arithmetic_coder.rs
@@ -66,7 +66,7 @@ impl<W: ACWrite> ArithmeticCoder<W> {
 
     pub fn flush(&mut self, io: &mut W) -> io::Result<()> {
         // assert state is normalized
-        // debug_assert!(self.x1 >> PREC_SHIFT == 0 && self.x2 >> PREC_SHIFT == 1);
+        debug_assert!(self.x1 >> PREC_SHIFT == 0 && self.x2 >> PREC_SHIFT == 1);
         io.flush(self.x2)
     }
 }

--- a/src/entropy_coding/arithmetic_coder.rs
+++ b/src/entropy_coding/arithmetic_coder.rs
@@ -66,7 +66,7 @@ impl<W: ACWrite> ArithmeticCoder<W> {
 
     pub fn flush(&mut self, io: &mut W) -> io::Result<()> {
         // assert state is normalized
-        debug_assert!(self.x1 >> PREC_SHIFT == 0 && self.x2 >> PREC_SHIFT == 1);
+        // debug_assert!(self.x1 >> PREC_SHIFT == 0 && self.x2 >> PREC_SHIFT == 1);
         io.flush(self.x2)
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,7 +1,7 @@
 use crate::entropy_coding;
 use std::{
     fs::File,
-    io::{self, BufReader, Read, Result},
+    io::{self, BufReader, Read, Result}, ops::{Index, IndexMut},
 };
 
 pub fn cmp(file1: &str, file2: &str) -> Result<()> {
@@ -86,5 +86,94 @@ impl entropy_coding::arithmetic_coder::ACWrite for ACStats {
 
     fn flush(&mut self, _padding: u32) -> io::Result<()> {
         Ok(())
+    }
+}
+
+struct RotatingBuffer<const N: usize> {
+    buf: [u16; N],
+    pos: usize,
+}
+
+impl<const N: usize> Index<usize> for RotatingBuffer<N> {
+    type Output = u16;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.buf[(self.pos + N - (index + 1)) % N]
+    }
+}
+
+impl<const N: usize> IndexMut<usize> for RotatingBuffer<N> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.buf[(self.pos + N - (index + 1)) % N]
+    }
+}
+
+impl<const N: usize> RotatingBuffer<N> {
+    pub fn new() -> Self {
+        Self { buf: [0; N], pos: 0 }
+    }
+
+    pub fn push(&mut self, value: u16) {
+        self.buf[self.pos] = value;
+        self.pos = (self.pos + 1) % N;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn rotating_buffer() {
+        let mut rb= RotatingBuffer::<4>::new();
+        rb.push(1);
+        rb.push(2);
+        rb.push(3);
+        rb.push(4);
+        assert_eq!(rb[0], 4);
+        assert_eq!(rb[1], 3);
+        assert_eq!(rb[2], 2);
+        assert_eq!(rb[3], 1);
+
+        rb.push(5);
+        assert_eq!(rb[0], 5);
+        assert_eq!(rb[1], 4);
+        assert_eq!(rb[2], 3);
+        assert_eq!(rb[3], 2);
+
+        rb.push(6);
+        rb.push(7);
+        rb.push(8);
+        assert_eq!(rb[0], 8);
+        assert_eq!(rb[1], 7);
+        assert_eq!(rb[2], 6);
+        assert_eq!(rb[3], 5);
+    }
+
+    #[test]
+    fn rotating_buffer_assingment() {
+        let mut rb= RotatingBuffer::<4>::new();
+        rb.push(10);
+        rb.push(20);
+        rb.push(30);
+        rb.push(40);
+        assert_eq!(rb[0], 40);
+        assert_eq!(rb[1], 30);
+        assert_eq!(rb[2], 20);
+        assert_eq!(rb[3], 10);
+
+        rb[1] = 99;
+        assert_eq!(rb[0], 40);
+        assert_eq!(rb[1], 99);
+        assert_eq!(rb[2], 20);
+        assert_eq!(rb[3], 10);
+
+        rb[0] = 100;
+        rb[2] = 98;
+        rb[3] = 97;
+        assert_eq!(rb[0], 100);
+        assert_eq!(rb[1], 99);
+        assert_eq!(rb[2], 98);
+        assert_eq!(rb[3], 97);
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -89,33 +89,35 @@ impl entropy_coding::arithmetic_coder::ACWrite for ACStats {
     }
 }
 
-struct RotatingBuffer<const N: usize> {
-    buf: [u16; N],
+struct RotatingBuffer<T, const N: usize> {
+    buf: [T; N],
     pos: usize,
 }
 
-impl<const N: usize> Index<usize> for RotatingBuffer<N> {
-    type Output = u16;
+impl<T, const N: usize> Index<usize> for RotatingBuffer<T, N> {
+    type Output = T;
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.buf[(self.pos + N - (index + 1)) % N]
     }
 }
 
-impl<const N: usize> IndexMut<usize> for RotatingBuffer<N> {
+impl<T, const N: usize> IndexMut<usize> for RotatingBuffer<T, N> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.buf[(self.pos + N - (index + 1)) % N]
     }
 }
 
-impl<const N: usize> RotatingBuffer<N> {
-    pub fn new() -> Self {
-        Self { buf: [0; N], pos: 0 }
-    }
-
-    pub fn push(&mut self, value: u16) {
+impl<T, const N: usize> RotatingBuffer<T, N> {
+    pub fn push(&mut self, value: T) {
         self.buf[self.pos] = value;
         self.pos = (self.pos + 1) % N;
+    }
+}
+
+impl<T: Default + Copy, const N: usize> RotatingBuffer<T, N> {
+    pub fn new() -> Self {
+        Self { buf: [T::default(); N], pos: 0 }
     }
 }
 
@@ -125,7 +127,7 @@ mod test {
 
     #[test]
     fn rotating_buffer() {
-        let mut rb= RotatingBuffer::<4>::new();
+        let mut rb= RotatingBuffer::<u16, 4>::new();
         rb.push(1);
         rb.push(2);
         rb.push(3);
@@ -152,7 +154,7 @@ mod test {
 
     #[test]
     fn rotating_buffer_assingment() {
-        let mut rb= RotatingBuffer::<4>::new();
+        let mut rb= RotatingBuffer::<u16, 4>::new();
         rb.push(10);
         rb.push(20);
         rb.push(30);

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -89,7 +89,7 @@ impl entropy_coding::arithmetic_coder::ACWrite for ACStats {
     }
 }
 
-struct RotatingBuffer<T, const N: usize> {
+pub struct RotatingBuffer<T, const N: usize> {
     buf: [T; N],
     pos: usize,
 }
@@ -118,6 +118,10 @@ impl<T, const N: usize> RotatingBuffer<T, N> {
 impl<T: Default + Copy, const N: usize> RotatingBuffer<T, N> {
     pub fn new() -> Self {
         Self { buf: [T::default(); N], pos: 0 }
+    }
+
+    pub fn init(value: T) -> Self {
+        Self { buf: [value; N], pos: 0 }
     }
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,7 +1,8 @@
 use crate::entropy_coding;
 use std::{
     fs::File,
-    io::{self, BufReader, Read, Result}, ops::{Index, IndexMut},
+    io::{self, BufReader, Read, Result},
+    ops::{Index, IndexMut},
 };
 
 pub fn cmp(file1: &str, file2: &str) -> Result<()> {
@@ -131,7 +132,7 @@ mod test {
 
     #[test]
     fn rotating_buffer() {
-        let mut rb= RotatingBuffer::<u16, 4>::new();
+        let mut rb = RotatingBuffer::<u16, 4>::new();
         rb.push(1);
         rb.push(2);
         rb.push(3);
@@ -158,7 +159,7 @@ mod test {
 
     #[test]
     fn rotating_buffer_assingment() {
-        let mut rb= RotatingBuffer::<u16, 4>::new();
+        let mut rb = RotatingBuffer::<u16, 4>::new();
         rb.push(10);
         rb.push(20);
         rb.push(30);

--- a/src/history/ac_history.rs
+++ b/src/history/ac_history.rs
@@ -8,9 +8,9 @@ use crate::{entropy_coding, u8, usize};
 use std::marker::PhantomData;
 
 pub struct ACHistory<M: Model> {
-    pos: u64,
+    pos: usize,
     bits: u64,
-    cache: RotatingBuffer<u16, 64>,
+    probs: RotatingBuffer<u16, 64>,
     max_bits: u8,
     model: M,
 }
@@ -20,7 +20,7 @@ impl<M: Model> ACHistory<M> {
         Self {
             pos: 0,
             bits: 0,
-            cache: RotatingBuffer::init(1 << 15),
+            probs: RotatingBuffer::init(1 << 15),
             max_bits,
             model,
         }
@@ -31,7 +31,7 @@ impl<M: Model> History for ACHistory<M> {
     fn update(&mut self, bit: u8) {
         let p = self.model.predict();
         self.model.update(bit);
-        self.cache.push(p);
+        self.probs.push(p);
 
         self.bits = (self.bits << 1) | u64::from(bit);
         self.pos += 1;
@@ -57,9 +57,9 @@ impl<M: Model> History for ACHistory<M> {
             idx: 0,
             max_bits: self.max_bits,
         };
-        for i in 0..64 {
+        for i in 0..self.pos.min(64) {
             let bit = u8!((self.bits >> i) & 1);
-            let p = self.cache[i];
+            let p = self.probs[i];
             let res = ac.encode(bit, p, &mut writer);
             if res.is_err() {
                 break;
@@ -67,7 +67,8 @@ impl<M: Model> History for ACHistory<M> {
         }
         // _ = ac.flush(&mut writer);
 
-        writer.state >> (32 - writer.idx)
+        // writer.state >> (32 - writer.idx)
+        writer.state.wrapping_shr(32 - writer.idx as u32)
     }
 }
 

--- a/src/history/ac_history.rs
+++ b/src/history/ac_history.rs
@@ -1,10 +1,10 @@
 use super::History;
 use crate::helpers::RotatingBuffer;
+use crate::{entropy_coding, u8, usize};
 use crate::{
     entropy_coding::arithmetic_coder::{ACWrite, ArithmeticCoder},
     models::{ACHashModel, Model},
 };
-use crate::{entropy_coding, u8, usize};
 use std::marker::PhantomData;
 
 pub struct ACHistory<M: Model> {

--- a/src/history/ac_history.rs
+++ b/src/history/ac_history.rs
@@ -1,26 +1,38 @@
 use super::History;
-use crate::u8;
+use crate::helpers::RotatingBuffer;
 use crate::{
     entropy_coding::arithmetic_coder::{ACWrite, ArithmeticCoder},
     models::{ACHashModel, Model},
 };
+use crate::{entropy_coding, u8, usize};
 use std::marker::PhantomData;
 
-pub struct ACHistory<M: ACHashModel> {
+pub struct ACHistory<M: Model> {
     pos: u64,
-    bits: u64, // TODO: u128?
+    bits: u64,
+    cache: RotatingBuffer<u16, 64>,
     max_bits: u8,
     model: M,
 }
 
-impl<M: ACHashModel> ACHistory<M> {
+impl<M: Model> ACHistory<M> {
     pub fn new(max_bits: u8, model: M) -> Self {
-        Self { pos: 0, bits: 0, max_bits, model }
+        Self {
+            pos: 0,
+            bits: 0,
+            cache: RotatingBuffer::init(1 << 15),
+            max_bits,
+            model,
+        }
     }
 }
 
-impl<M: ACHashModel> History for ACHistory<M> {
+impl<M: Model> History for ACHistory<M> {
     fn update(&mut self, bit: u8) {
+        let p = self.model.predict();
+        self.model.update(bit);
+        self.cache.push(p);
+
         self.bits = (self.bits << 1) | u64::from(bit);
         self.pos += 1;
     }
@@ -33,10 +45,10 @@ impl<M: ACHashModel> History for ACHistory<M> {
             idx: 0,
             max_bits: self.max_bits,
         };
-        self.model.align(u8!(self.pos & 7));
         for i in 0..64 {
             let bit = u8!((self.bits >> i) & 1);
-            let res = ac.encode(bit, self.model.predict(), &mut writer);
+            let p = self.cache[i];
+            let res = ac.encode(bit, p, &mut writer);
             if res.is_err() {
                 break;
             }

--- a/src/history/ac_history.rs
+++ b/src/history/ac_history.rs
@@ -38,6 +38,18 @@ impl<M: Model> History for ACHistory<M> {
     }
 
     fn hash(&mut self) -> u32 {
+        // if self.pos == 100 {
+        //     let mut entropy = 0.0;
+        //     for i in 0..64 {
+        //         let bit = u8!((self.bits >> i) & 1);
+        //         let p = self.cache[i];
+        //         let prob = f64::from(p) / 65536.0;
+        //         let prob = if bit == 1 { prob } else { 1.0 - prob };
+        //         entropy += -prob.log2();
+        //         println!("bit={}, p={}, h={}", bit, p, entropy);
+        //     }
+        // }
+
         let mut ac = ArithmeticCoder::new_coder();
         let mut writer = EntropyWriter {
             state: 0,
@@ -53,6 +65,7 @@ impl<M: Model> History for ACHistory<M> {
                 break;
             }
         }
+        // _ = ac.flush(&mut writer);
 
         writer.state >> (32 - writer.idx)
     }
@@ -96,6 +109,8 @@ impl ACWrite for EntropyWriter {
     }
 
     fn flush(&mut self, _padding: u32) -> std::io::Result<()> {
-        unimplemented!("Entropy writer doesn't implement flushing")
+        self.write_bit(1)?;
+        debug_assert!(self.rev_bits == 0);
+        Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,7 +148,8 @@ fn init_model() -> impl Model {
     // BestOfTwoModel::new(Order0::new(), Order1::new())
     // BestOfTwoModel::new(Order0Entropy::new(), Order0::new())
     // BestOfTwoModel::new(Order1::new(), Order0Entropy::new())
-    OrderNEntropy::new(11, 3, ACHistory::new(8, StationaryModel::for_book1()))
+    // OrderNEntropy::new(11, 3, ACHistory::new(8, StationaryModel::for_book1()))
+    Order0::new()
 }
 
 fn print_usage_and_exit(msg: &str) -> ! {

--- a/src/models/frozen.rs
+++ b/src/models/frozen.rs
@@ -1,4 +1,7 @@
-use crate::{models::{AdaptiveModel, Model}, unroll_for};
+use crate::{
+    models::{AdaptiveModel, Model},
+    unroll_for,
+};
 
 pub struct FrozenModel<T: AdaptiveModel> {
     pub model: T,

--- a/src/models/frozen.rs
+++ b/src/models/frozen.rs
@@ -1,4 +1,4 @@
-use crate::models::{AdaptiveModel, Model};
+use crate::{models::{AdaptiveModel, Model}, unroll_for};
 
 pub struct FrozenModel<T: AdaptiveModel> {
     pub model: T,
@@ -7,6 +7,21 @@ pub struct FrozenModel<T: AdaptiveModel> {
 impl<T: AdaptiveModel> FrozenModel<T> {
     pub fn new(model: T) -> Self {
         Self { model }
+    }
+
+    pub fn train(&mut self, data: &[u8]) {
+        for byte in data {
+            unroll_for!(bit in byte, {
+                self.model.adapt(bit);
+                self.model.update(bit);
+            });
+        }
+    }
+}
+
+impl<T: AdaptiveModel + Clone> Clone for FrozenModel<T> {
+    fn clone(&self) -> Self {
+        Self { model: self.model.clone() }
     }
 }
 

--- a/src/models/order0.rs
+++ b/src/models/order0.rs
@@ -1,5 +1,6 @@
 use super::{counter::Counter, AdaptiveModel};
 
+#[derive(Clone)]
 pub struct Order0 {
     stats: [Counter; 1 << 11],
     history: u8,

--- a/src/models/order1.rs
+++ b/src/models/order1.rs
@@ -1,6 +1,7 @@
 use super::{counter::Counter, AdaptiveModel};
 use crate::usize;
 
+#[derive(Clone)]
 pub struct Order1 {
     stats: Vec<Counter>,
     history: u16,


### PR DESCRIPTION
Previously we were restricted to what models we'd be able to use.
Keeping predictions in a rotating buffer allows the model to move forwards but the encoder to hash backwards.  
Also implements a fixed size generic rotating buffer, duh.

Did not see any major improvements in compression (actually order0 kinda sucks, I'll have to investigate) but that's more model dependent than algorithmically wrong.
More pedantic/correctness fixes may be done for the flush but it doesn't really matter if we're cropping the hash.

I also tried Shelwien's ideas about reusing AC state to encode forwards but couldn't get it to work. I think I did some ANS (uABS) tests as well but more effort should be invested there as well.

Future ideas:
- fitting more context in the hash
  - skip encode of unpredictable bits (when p is close to 1/2)
  - or maybe it works better by eliminating predictable bits (when p is far from 1/2) 
  - stronger models
  - stripped models (skip odd/even bits/bytes)
- minimizing L1 entropy
  - model param search?
- use adaptive models
  - requires re-hashing & updating old counts
  - perhaps suitable for smaller prefix models